### PR TITLE
removed deprecated method used for getting child items

### DIFF
--- a/printers/ricoh.py
+++ b/printers/ricoh.py
@@ -143,9 +143,9 @@ class Ricoh:
                 )
                 result = self._post_to_copier('searchObjects', search_options, ricoh_xml.search_xml)
                 try:
-                    row_list = result['tree'].find('{http://schemas.xmlsoap.org/soap/envelope/}Body') \
+                    row_list = list(result['tree'].find('{http://schemas.xmlsoap.org/soap/envelope/}Body') \
                         .find('{http://www.ricoh.co.jp/xmlns/soap/rdh/udirectory}searchObjectsResponse') \
-                        .find('rowList').getchildren()
+                        .find('rowList'))
 
                     for row in row_list:
                         _user_id = row.find('item').find('propVal').text
@@ -184,7 +184,7 @@ class Ricoh:
 
             for user in users_with_details:
                 obj = {}
-                for item in user.getchildren():
+                for item in list(user):
                     obj[item.find('propName').text.replace(':', '')] = item.find('propVal').text
 
                 User.__new__.__defaults__ = ('',) * len(User._fields)


### PR DESCRIPTION
Users were not being pulled from machines due to failures in _get_user_ids():
`AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'`

Did some poking around, found that the `getchildren` method was deprecated in Python 3.9.

Replaced the bad methods with list calls to get a list of child items.